### PR TITLE
Fixed #10

### DIFF
--- a/io/src/librealsense/librealsense_device_manager.cpp
+++ b/io/src/librealsense/librealsense_device_manager.cpp
@@ -86,7 +86,7 @@ pcl::io::librealsense::LibRealSenseDeviceManager::captureDevice (LibRealSenseGra
   boost::mutex::scoped_lock lock (mutex_);
   for (size_t i = 0; i < context_.get_device_count (); ++i)
   {
-    if (context_.get_device (i)->get_serial () == sn)
+    if (context_.get_device (i)->get_serial () == sn || context_.get_device (i)->get_serial () == sn + " ")
     {
       if (isCaptured (sn))
         THROW_IO_EXCEPTION ("device with serial number %s is captured by another grabber", sn.c_str ());


### PR DESCRIPTION
The serial number of my SR300 is "60520100113 ", it ends with a space. I think some devices must have the same problem and it is hard to notice the exist of the space, so I modified the code for the convenience of the users.
@huningxin , please take a look:)
